### PR TITLE
Force a coarse move based on current piezo voltage

### DIFF
--- a/HOMS_XRT/HOMS_XRT_PLC/Common/POUs/HOMS_FBs/FB_PitchControl.TcPOU
+++ b/HOMS_XRT/HOMS_XRT_PLC/Common/POUs/HOMS_FBs/FB_PitchControl.TcPOU
@@ -183,13 +183,14 @@ CASE PC_State OF
 	PCM_MoveRequested: 
 		//A move has been requested, is it within range of the piezo?
 		IF WithinRange(ValA:=rSetpoint, Center:=rPrevStepperPos, Range:=cPiezoRange, Offset:=0)
-            //Ensure that the piezo is not currently outside the operating range
-            //Otherwise, force a coarse move that will rezero the piezo travel
-            AND WithinRange(ValA:=Pitch.Piezo.rActVoltage,
-                            Center:=(Pitch.Piezo.LowerVoltage + Pitch.Piezo.UpperVoltage)/2.0,
-                            Range:=cOperatingRegion*cPiezoRange, Offset:=0)
-            THEN
-            //Move is within the nominal range of the piezo
+                //Ensure that the piezo is not currently outside the operating range
+                //Otherwise, force a coarse move that will rezero the piezo travel
+	        AND WithinRange(ValA:=Pitch.Piezo.rActVoltage,
+                                Center:=(Pitch.Piezo.LowerVoltage + Pitch.Piezo.UpperVoltage)/2.0,
+                                Range:=cOperatingRegion*(Pitch.Piezo.UpperVoltage - Pitch.Piezo.LowerVoltage)/2.0,
+                                Offset:=0)
+                THEN
+            		//Move is within the nominal range of the piezo
 			fbFormatString.sFormat := 'Within range, fine move %f';
 			fbFormatString.arg1 := F_REAL(rSetpoint);
 			fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);

--- a/HOMS_XRT/HOMS_XRT_PLC/Common/POUs/HOMS_FBs/FB_PitchControl.TcPOU
+++ b/HOMS_XRT/HOMS_XRT_PLC/Common/POUs/HOMS_FBs/FB_PitchControl.TcPOU
@@ -73,6 +73,7 @@ VAR
 END_VAR
 VAR CONSTANT
 	cPiezoRange	:	REAL := 60; // 90um of stroke to the piezo, which means a 180urad stroke...
+    cOperatingRegion : REAL := 0.75; // Only use a fraction of the piezo range before forcing a coarse move    
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* HOMS Pitch Control
@@ -181,8 +182,14 @@ CASE PC_State OF
 		
 	PCM_MoveRequested: 
 		//A move has been requested, is it within range of the piezo?
-		IF WithinRange(ValA:=rSetpoint, Center:=rPrevStepperPos, Range:=cPiezoRange, Offset:=0) THEN
-			//Move is within the nominal range of the piezo
+		IF WithinRange(ValA:=rSetpoint, Center:=rPrevStepperPos, Range:=cPiezoRange, Offset:=0)
+            //Ensure that the piezo is not currently outside the operating range
+            //Otherwise, force a coarse move that will rezero the piezo travel
+            AND WithinRange(ValA:=Pitch.Piezo.rActVoltage,
+                            Center:=(Pitch.Piezo.LowerVoltage + Pitch.Piezo.UpperVoltage)/2.0,
+                            Range:=cOperatingRegion*cPiezoRange, Offset:=0)
+            THEN
+            //Move is within the nominal range of the piezo
 			fbFormatString.sFormat := 'Within range, fine move %f';
 			fbFormatString.arg1 := F_REAL(rSetpoint);
 			fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);


### PR DESCRIPTION
Solution Description
----
The current implementation only checked whether or not the requested position was within a reasonable range of the piezo center, without considering if the piezo was currently at an extreme. Now, if the current piezo voltage is not within `cOperatingRegion` *` cPiezoRange` of the center, a coarse move will be forced.

The idea is, if an operator does a gantry move and the piezo ends up close to a limit, a small tweak will cause a coarse move re-centering the piezo range. This isn't quite the same as the `rezero` button, but I think the result is the same. This also has the added bonus that multiple small tweaks won't keep us pinned at one limit, just eventually if you tweak enough, the stepper will get involved.

Implementation Thoughts
---
* I imagine that we could have a single `WithinRange` call that calculated the remaining range of the piezo base on the current piezo voltage.  Wouldn't be so hard to do, just not sure if it gets us anywhere this doesn't besides a bonus feeling of superiority

